### PR TITLE
Remove deprecated div_for form helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ In a Rails application, the view files should contain the least amount of logic 
 Rails also does a great job of supplying built in ActionView helper methods that you can implement to efficiently code the views. For example, if you wanted to create a `div` for a set of blog posts that you want to iterate over, you can implement the following code:
 
 ```erb
-<%= div_for(@post, class: "post-index-page") do %>
-  <p><%= @post.title %> <%= @post.summary %></p>
+<%= content_tag(:div, @post, class: "post-index-page") do %>
+  <%= content_tag(:p, "#{@post.title}: #{@post.summary}") %>
 <% end %>
 ```
 
@@ -70,7 +70,7 @@ Which is translated to the following HTML markup:
 
 ```html
 <div id="post_42" class="post post-index-page">
-  <p><strong>My Amazing Blog Post</strong> With an incredible summary</p>
+  <p>My Amazing Blog Post: With an incredible summary</p>
 </div>
 ```
 


### PR DESCRIPTION
**The `div_for` helper has been deprecated:** https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actionview-helpers-recordtaghelper-moved-to-external-gem-record-tag-helper

Therefore if a student actually codes along with this README, they will get an error message.

**My proposed change shows how to use `content_tag` instead.**

Technically the syntax in this proposed change is also currently soft deprecated, in favor of
```erb
<%= tag.div(@post, class: "post-index-page") do %>
  <%= tag.p("#{@post.title}: #{@post.summary}") %>
<% end %>
```
(Rails issue here: https://github.com/rails/rails/issues/25195)

But the version I'm suggesting works with Rails 4 and is less confusing-looking in my opinion.

#staff